### PR TITLE
Remove Result.unwrap/1

### DIFF
--- a/lib/civilcode/result.ex
+++ b/lib/civilcode/result.ex
@@ -5,13 +5,6 @@ defmodule CivilCode.Result do
   @type error(any) :: {:error, any}
   @type t(any) :: ok(any) | error(any)
 
-  @spec unwrap(t(any) | [t(any)]) :: any
-  def unwrap({_, payload}), do: payload
-
-  def unwrap(results) when is_list(results) do
-    Enum.map(results, &unwrap/1)
-  end
-
   @spec unwrap!({:ok, any}) :: any
   def unwrap!({:ok, payload}), do: payload
 


### PR DESCRIPTION
Blind unwrapping like this is dangerous as there is no explicit
pattern matching on both sum types which is the original reason why
sum types exist in the first place, to force the developer to
explicitly deal with both cases.