### PR TITLE
Correctly spec result type

### DIFF
--- a/lib/civilcode/types/result.ex
+++ b/lib/civilcode/types/result.ex
@@ -5,7 +5,7 @@ defmodule CivilCode.Result do
 
   @type ok(any) :: {:ok, any}
   @type error(any) :: {:error, any}
-  @type t(any) :: ok(any) | error(any)
+  @type t(a, b) :: ok(a) | error(b)
 
   @spec unwrap!({:ok, any}) :: any
   def unwrap!({:ok, payload}), do: payload
@@ -20,15 +20,15 @@ defmodule CivilCode.Result do
   @spec error(any) :: error(any)
   def error(result), do: {:error, result}
 
-  @spec error?(t(any)) :: boolean
+  @spec error?(t(any, any)) :: boolean
   def error?({:error, _}), do: true
   def error?(_), do: false
 
-  @spec map(t(any), (any -> any)) :: t(any)
+  @spec map(t(any, any), (any -> any)) :: t(any, any)
   def map({:ok, payload}, func), do: ok(func.(payload))
   def map(result, _func), do: result
 
-  @spec combine(t(any), t(any)) :: {:ok, [any()]} | {:error, [any()]}
+  @spec combine(t(any, any), t(any, any)) :: {:ok, [any()]} | {:error, [any()]}
   def combine({:ok, lhr}, {:ok, rhr}) do
     {:ok, List.flatten([lhr, rhr])}
   end


### PR DESCRIPTION
Result can either be 'a or 'b