### PR TITLE
Upgrade Ecto 3.1.7 => 3.2.2

### DIFF
--- a/lib/civilcode/domain/value_object.date.ex
+++ b/lib/civilcode/domain/value_object.date.ex
@@ -40,7 +40,7 @@ defmodule CivilCode.ValueObject.Date do
 
       defoverridable new: 1
 
-      @behaviour Elixir.Ecto.Type
+      use Elixir.Ecto.Type
 
       @impl true
       def type, do: :date

--- a/lib/civilcode/domain/value_object.decimal.ex
+++ b/lib/civilcode/domain/value_object.decimal.ex
@@ -40,7 +40,7 @@ defmodule CivilCode.ValueObject.Decimal do
 
       defoverridable new: 1
 
-      @behaviour Elixir.Ecto.Type
+      use Elixir.Ecto.Type
 
       @impl true
       def type, do: :decimal

--- a/lib/civilcode/domain/value_object.enum.ex
+++ b/lib/civilcode/domain/value_object.enum.ex
@@ -22,7 +22,7 @@ defmodule CivilCode.ValueObject.Enum do
       Enum.all?(values, &is_atom/1) || raise "All values must be atoms"
       schema && (is_atom(schema) || raise "Option schema must be atom")
 
-      @behaviour Ecto.Type
+      use Ecto.Type
       @__input_values__ Enum.map(values, &Atom.to_string/1)
       @__output_values__ values
       @__schema__ schema

--- a/lib/civilcode/domain/value_object.non_neg_integer.ex
+++ b/lib/civilcode/domain/value_object.non_neg_integer.ex
@@ -38,7 +38,7 @@ defmodule CivilCode.ValueObject.NonNegInteger do
 
       defoverridable new: 1
 
-      @behaviour Elixir.Ecto.Type
+      use Elixir.Ecto.Type
 
       @impl true
       def type, do: :integer

--- a/lib/civilcode/domain/value_object.string.ex
+++ b/lib/civilcode/domain/value_object.string.ex
@@ -30,7 +30,7 @@ defmodule CivilCode.ValueObject.String do
 
       defoverridable new: 1
 
-      @behaviour Elixir.Ecto.Type
+      use Elixir.Ecto.Type
 
       @impl true
       def type, do: :string

--- a/lib/civilcode/domain/value_object.uuid.ex
+++ b/lib/civilcode/domain/value_object.uuid.ex
@@ -34,7 +34,7 @@ defmodule CivilCode.ValueObject.Uuid do
         |> Result.ok()
       end
 
-      @behaviour Elixir.Ecto.Type
+      use Elixir.Ecto.Type
 
       @impl true
       def type, do: :uuid

--- a/mix.lock
+++ b/mix.lock
@@ -3,7 +3,7 @@
   "decimal": {:hex, :decimal, "1.8.0", "ca462e0d885f09a1c5a342dbd7c1dcf27ea63548c65a65e67334f4b61803822e", [:mix], [], "hexpm"},
   "dialyxir": {:hex, :dialyxir, "1.0.0-rc.6", "78e97d9c0ff1b5521dd68041193891aebebce52fc3b93463c0a6806874557d7d", [:mix], [{:erlex, "~> 0.2.1", [hex: :erlex, repo: "hexpm", optional: false]}], "hexpm"},
   "earmark": {:hex, :earmark, "1.3.3", "5e8be428fcef362692b6dbd7dc55bdc7023da26d995cb3fb19aa4bd682bfd3f9", [:mix], [], "hexpm"},
-  "ecto": {:hex, :ecto, "3.1.7", "fa21d06ef56cdc2fdaa62574e8c3ba34a2751d44ea34c30bc65f0728421043e5", [:mix], [{:decimal, "~> 1.6", [hex: :decimal, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: true]}], "hexpm"},
+  "ecto": {:hex, :ecto, "3.2.2", "bb6d1dbcd7ef975b60637e63182e56f3d7d0b5dd9c46d4b9d6183a5c455d65d1", [:mix], [{:decimal, "~> 1.6", [hex: :decimal, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: true]}], "hexpm"},
   "elixir_uuid": {:hex, :elixir_uuid, "1.2.0", "ff26e938f95830b1db152cb6e594d711c10c02c6391236900ddd070a6b01271d", [:mix], [], "hexpm"},
   "erlex": {:hex, :erlex, "0.2.4", "23791959df45fe8f01f388c6f7eb733cc361668cbeedd801bf491c55a029917b", [:mix], [], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.20.2", "1bd0dfb0304bade58beb77f20f21ee3558cc3c753743ae0ddbb0fd7ba2912331", [:mix], [{:earmark, "~> 1.3", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.10", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},


### PR DESCRIPTION
This required a change to include the Ecto.Type behaviour to include
defaults for some functions, e.g. equal?/2.