### PR TITLE
Don't use custom types for union type

### DIFF
--- a/lib/civilcode/types/result.ex
+++ b/lib/civilcode/types/result.ex
@@ -7,7 +7,7 @@ defmodule CivilCode.Result do
   @type error(any) :: {:error, any}
 
   @typedoc "the two-track type"
-  @type t(a, b) :: ok(a) | error(b)
+  @type t(a, b) :: {:ok, a} | {:error, b}
 
   @spec unwrap!(ok(any)) :: any | no_return
   def unwrap!({:ok, payload}), do: payload


### PR DESCRIPTION
Hammox does not handle this currently so let's make it easier for the library.

We'll hold off on merging this, perhaps it will get fixed: https://github.com/msz/hammox/issues/14