### PR TITLE
Handle :error return from Ecto.Type.cast

### DIFF
--- a/lib/civilcode/domain/value_object/date.ex
+++ b/lib/civilcode/domain/value_object/date.ex
@@ -14,8 +14,9 @@ defmodule CivilCode.ValueObject.Date do
       end
 
       def new(value) when is_binary(value) do
-        with {:ok, value} <- Ecto.Type.cast(:date, value) do
-          new(value)
+        case Ecto.Type.cast(:date, value) do
+          {:ok, casted_value} -> new(casted_value)
+          :error -> Result.error("is invalid")
         end
       end
 

--- a/lib/civilcode/domain/value_object/decimal.ex
+++ b/lib/civilcode/domain/value_object/decimal.ex
@@ -26,8 +26,9 @@ defmodule CivilCode.ValueObject.Decimal do
       end
 
       def new(value) when is_binary(value) or is_integer(value) do
-        with {:ok, value} <- Ecto.Type.cast(:decimal, value) do
-          new(value)
+        case Ecto.Type.cast(:decimal, value) do
+          {:ok, casted_value} -> new(casted_value)
+          :error -> Result.error("is invalid")
         end
       end
 

--- a/lib/civilcode/domain/value_object/naive_money.ex
+++ b/lib/civilcode/domain/value_object/naive_money.ex
@@ -21,8 +21,9 @@ defmodule CivilCode.ValueObject.NaiveMoney do
       end
 
       def new(value) when is_binary(value) or is_integer(value) do
-        with {:ok, value} <- Ecto.Type.cast(:decimal, value) do
-          new(value)
+        case Ecto.Type.cast(:decimal, value) do
+          {:ok, casted_value} -> new(casted_value)
+          :error -> Result.error("is invalid")
         end
       end
 

--- a/test/civilcode/domain/value_object/date_test.exs
+++ b/test/civilcode/domain/value_object/date_test.exs
@@ -3,10 +3,21 @@ defmodule CivilCode.ValueObject.DateTest do
 
   import ExUnit.CaptureIO
 
+  describe "new" do
+    test "valid date string returns a date" do
+      assert Fixtures.Date.new("2001-01-01") == {:ok, %Fixtures.Date{value: ~D[2001-01-01]}}
+    end
+
+    test "invalid date returns an error" do
+      assert Fixtures.Date.new("2001-01-00") == {:error, "is invalid"}
+      assert Fixtures.Date.new("20010-01-01") == {:error, "is invalid"}
+      assert Fixtures.Date.new("2000") == {:error, "is invalid"}
+    end
+  end
+
   describe "inspect" do
     test "returns a string representation" do
       value = Fixtures.Date.new!("2001-01-02")
-
       inspection = fn -> IO.inspect(value) end
       assert capture_io(inspection) == "#Fixtures.Date<2001-01-02>\n"
     end

--- a/test/civilcode/domain/value_object/decimal_test.exs
+++ b/test/civilcode/domain/value_object/decimal_test.exs
@@ -3,6 +3,18 @@ defmodule CivilCode.ValueObject.DecimalTest do
 
   import ExUnit.CaptureIO
 
+  describe "new" do
+    test "valid decimal string returns a decimal" do
+      assert Fixtures.Decimal.new("100.0") ==
+               {:ok, %Fixtures.Decimal{value: Decimal.new("100.0")}}
+    end
+
+    test "invalid decimal returns an error" do
+      assert Fixtures.Decimal.new("100.00.00") == {:error, "is invalid"}
+      assert Fixtures.Decimal.new(":string:") == {:error, "is invalid"}
+    end
+  end
+
   describe "inspect" do
     test "returns a string representation" do
       value = Fixtures.Decimal.new!("0.10")

--- a/test/civilcode/domain/value_object/naive_money_test.exs
+++ b/test/civilcode/domain/value_object/naive_money_test.exs
@@ -3,6 +3,18 @@ defmodule CivilCode.ValueObject.NaiveMoneyTest do
 
   import ExUnit.CaptureIO
 
+  describe "new" do
+    test "valid money string returns a money" do
+      assert Fixtures.NaiveMoney.new("100.0") ==
+               {:ok, %Fixtures.NaiveMoney{value: Decimal.new("100.0")}}
+    end
+
+    test "invalid money returns an error" do
+      assert Fixtures.NaiveMoney.new("100.00.00") == {:error, "is invalid"}
+      assert Fixtures.NaiveMoney.new(":string:") == {:error, "is invalid"}
+    end
+  end
+
   describe "inspect" do
     test "returns a string representation" do
       value = Fixtures.NaiveMoney.new!("123.45")


### PR DESCRIPTION
This resolves an exception being thrown when recording an invalid date in a form.